### PR TITLE
This commit fixes a bug in the workflow canvas where nodes would jump…

### DIFF
--- a/client/src/components/workflow/custom-nodes.tsx
+++ b/client/src/components/workflow/custom-nodes.tsx
@@ -26,7 +26,6 @@ export function CustomWorkflowNode({ data, type, selected }: CustomNodeProps) {
         selected ? 'border-coral ring-2 ring-coral' : 'border-border-light'
       }`}
       data-testid={`workflow-node-${type}`}
-      style={{ position: 'relative' }} /* Add position relative to fix node positioning */
     >
       <div className="relative">
         {showInputHandle && (

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -284,11 +284,11 @@ body, html {
 }
 
 .workflow-node {
-  transition: box-shadow 0.2s ease;
+  /* transition: box-shadow 0.2s ease; */
 }
 
 .workflow-node:hover {
-  box-shadow: 0 8px 25px rgba(0, 0, 0, 0.15);
+  /* box-shadow: 0 8px 25px rgba(0, 0, 0, 0.15); */
 }
 
 .sidebar-item:hover {

--- a/server.log
+++ b/server.log
@@ -1,0 +1,3 @@
+
+> rest-express@1.0.0 dev
+> cross-env NODE_ENV=development tsx server/index.ts


### PR DESCRIPTION
… to the top-left corner when being dragged.

The issue was caused by a CSS transition on the `box-shadow` property of the custom nodes. This transition interfered with React Flow's position updates during drag operations, causing the node's position to be incorrectly calculated.

The fix involves:
- Removing the `transition` and `box-shadow` CSS properties from the `.workflow-node` class to prevent the conflict.
- Removing an unnecessary `position: relative` style from the custom node component, allowing React Flow to manage the positioning entirely.

The fix has been visually verified by a Playwright script that demonstrates the drag-and-drop functionality is now working correctly.